### PR TITLE
Add fix for hasOwnProperty is not a function error

### DIFF
--- a/renderjson.js
+++ b/renderjson.js
@@ -72,7 +72,7 @@ var module;
         el.insertBefore(child, el.firstChild);
         return el;
     }
-    var isempty = function(obj) { for (var k in obj) if (obj.hasOwnProperty && obj.hasOwnProperty(k)) return false;
+    var isempty = function(obj) { for (var k in obj) if (Object.hasOwnProperty.call(obj, k)) return false;
                                   return true; }
     var text = function(txt) { return document.createTextNode(txt) };
     var div = function() { return document.createElement("div") };

--- a/renderjson.js
+++ b/renderjson.js
@@ -72,7 +72,7 @@ var module;
         el.insertBefore(child, el.firstChild);
         return el;
     }
-    var isempty = function(obj) { for (var k in obj) if (obj.hasOwnProperty(k)) return false;
+    var isempty = function(obj) { for (var k in obj) if (obj.hasOwnProperty && obj.hasOwnProperty(k)) return false;
                                   return true; }
     var text = function(txt) { return document.createTextNode(txt) };
     var div = function() { return document.createElement("div") };


### PR DESCRIPTION
I ran into a scenario where a node didn't have a prototype (or hasOwnProperty method). This apparently happens if an object is created using `Object.create(null)`

This small fix just checks for the `hasOwnProperty` method before trying to call it.