### PR TITLE
Add Javascript Object mode

### DIFF
--- a/renderjson.js
+++ b/renderjson.js
@@ -86,6 +86,19 @@ var module;
                                                    a.onclick = function(e) { callback(); if (e) e.stopPropagation(); return false; };
                                                    return a; };
 
+    var protoCopy = function (obj) {
+        var output = {};
+        for (var o = obj; o != null; o = Object.getPrototypeOf(o)) {
+            var oKeys = Object.getOwnPropertyNames(o);
+            for (var i=0; i < oKeys.length; i++) {
+                var key = oKeys[i];
+                if (typeof output[key] !== 'undefined') continue;
+                output[key] = obj[key];
+            }
+        }
+        return output;
+    }  
+
     function _renderjson(json, indent, dont_indent, show_level, max_string, sort_objects) {
         var my_indent = dont_indent ? "" : indent;
 
@@ -119,6 +132,9 @@ var module;
                 return append(span("string"), themetext(null, my_indent, "string", JSON.stringify(json)));
             });
 
+        if(renderjson.js_mode && typeof(json) == "function")
+            return themetext(null, my_indent, typeof(json), json.toString());
+
         if (typeof(json) != "object") // Strings, numbers and bools
             return themetext(null, my_indent, typeof(json), JSON.stringify(json));
 
@@ -138,6 +154,7 @@ var module;
         }
 
         // object
+        if(renderjson.js_mode) json = protoCopy(json);
         if (isempty(json))
             return themetext(null, my_indent, "object syntax", "{}");
 
@@ -165,6 +182,9 @@ var module;
         pre.className = "renderjson";
         return pre;
     }
+    
+    renderjson.set_js_mode = function(js_mode_bool) { renderjson.js_mode = js_mode_bool; return renderjson; };
+    
     renderjson.set_icons = function(show, hide) { renderjson.show = show;
                                                   renderjson.hide = hide;
                                                   return renderjson; };
@@ -181,9 +201,11 @@ var module;
     // Backwards compatiblity. Use set_show_to_level() for new code.
     renderjson.set_show_by_default = function(show) { renderjson.show_to_level = show ? Number.MAX_VALUE : 0;
                                                       return renderjson; };
+                                                      
     renderjson.set_icons('⊕', '⊖');
     renderjson.set_show_by_default(false);
     renderjson.set_sort_objects(false);
     renderjson.set_max_string_length("none");
-    return renderjson;
+    renderjson.set_js_mode(false);
+    return renderjson;    
 })();

--- a/renderjson.js
+++ b/renderjson.js
@@ -132,8 +132,19 @@ var module;
                 return append(span("string"), themetext(null, my_indent, "string", JSON.stringify(json)));
             });
 
+        //function
         if(renderjson.js_mode && typeof(json) == "function")
-            return themetext(null, my_indent, typeof(json), json.toString());
+            return disclosure("function() {", "...", "}", "function", function() {
+                var fnParts = json.toString().match(/^([^{]*{)([\s\S]*)(})\s?$/)
+                var fnSig = fnParts && fnParts[1] ? fnParts[1] : "function() {";
+                var fnBody = fnParts && fnParts[2] ? fnParts[2] : "";
+                return append(
+                    span("function"),
+                    themetext("function syntax", fnSig, null, "\n"),
+                    themetext(null, indent, "function", fnBody),
+                    text("\n"),
+                    themetext(null, indent, "function syntax", "}"));
+            }); 
 
         if (typeof(json) != "object") // Strings, numbers and bools
             return themetext(null, my_indent, typeof(json), JSON.stringify(json));

--- a/test.html
+++ b/test.html
@@ -11,6 +11,8 @@
       .renderjson .boolean { color: blueviolet; }
       .renderjson .key    { color: darkblue; }
       .renderjson .keyword { color: blue; }
+      .renderjson .function { color: dimgray; }
+      .renderjson .function.syntax { color: deeppink; }      
       .renderjson .object.syntax { color: lightseagreen; }
       .renderjson .array.syntax  { color: orange; }
     </style>

--- a/test.html
+++ b/test.html
@@ -23,15 +23,33 @@
 
     <script type="text/javascript" src="renderjson.js"></script>
     <script>
+      
+      function Other() {}
+      Other.prototype.blah = "hello";
+      
+      function Something() {
+        this.blah=123;
+        this.ha=456;
+      }
+      Something.prototype.ha="nope";
+      Something.prototype.yolo="yes, sir";
+      Something.prototype.nope = {a:1,b:2,c:3,d: new Object(), e: new Other()};
+      Something.prototype.fn = function() { console.log('hi'); };
+      
+      var myThing = new Something();
+      
+      
 document.getElementById("dest").appendChild(
   renderjson//.set_show_by_default(true)
             //.set_show_to_level(2)
             //.set_sort_objects(true)
             //.set_icons('+', '-')
-              .set_max_string_length(100)
+            .set_js_mode(true)
+            .set_max_string_length(100)
     ([
 // Examples from http://json.org/example.html
 {
+    something: myThing,
     "glossary": {
         "title": "example glossary",
 		"GlossDiv": {


### PR DESCRIPTION
I added the ability to run in "Javascript Mode" which is for handling javascript objects. This mode causes two changes
- Traverses the prototype chain
- Stringifys Functions

I'm not sure if this is a feature that is valuable to you or not, but I figured I might as well submit it.
