### PR TITLE
Allow script to run in strict mode

### DIFF
--- a/renderjson.js
+++ b/renderjson.js
@@ -50,8 +50,14 @@
 //     .object.syntax ("{", "}")
 //     .array.syntax  ("[", "]")
 
-var module;
-(module||{}).exports = renderjson = (function() {
+(function (renderjson) {
+    if (typeof module === "object") {
+        module.exports = renderjson;
+    }
+    if (typeof window !== "undefined") {
+        window.renderjson = renderjson;
+    }
+}) (function() {
     var themetext = function(/* [class, text]+ */) {
         var spans = [];
         while (arguments.length)
@@ -186,4 +192,4 @@ var module;
     renderjson.set_sort_objects(false);
     renderjson.set_max_string_length("none");
     return renderjson;
-})();
+}());


### PR DESCRIPTION
If I bundle this script to another one which runs in strict mode the script initialization fails as it implicitly  injects `renderjson` to global context. This PR fixes this.
```
ReferenceError: Strict mode forbids implicit creation of global property 'renderjson'
```

This could be further extended to address compatibility with other loader types (  https://github.com/caldwell/renderjson/issues/11 the `renderjson` variable leaks to global scope.)  similar to what other popular libraries do: https://github.com/kriskowal/q/blob/v1/q.js#L29