### PR TITLE
Support DOM elements by simply appending them to the output

### DIFF
--- a/renderjson.js
+++ b/renderjson.js
@@ -148,6 +148,9 @@ var module, window, define, renderjson=(function() {
             });
         }
 
+        if(json instanceof HTMLElement)
+          return json;
+
         // object
         if (isempty(json, options.property_list))
             return themetext(null, my_indent, "object syntax", "{}");


### PR DESCRIPTION
Greetings! This patch facilitates the inclusion of DOM elements in the JSON data rendered with renderjson. With this one could modify the json ( for example with the 'apply' method in a library such as [jsonpath](https://github.com/dchester/jsonpath)) so as to contain custom DOM elements & formatting for specific items before passing the entire document to renderjson as outlined in the docs. Before this patch, the createTextNode method would result in raw html being rendered on the output DOM structure whereas now DOM elements will simply be added to it.

I've tested and verified this locally, though if this patch is unagreeable or won't work for any particular use case, let me know and we can try to devise and acceptable solution.

Thank you for your time.