### PR TITLE
feat: handle id/ref in json #35

### DIFF
--- a/resolvejson.js
+++ b/resolvejson.js
@@ -32,7 +32,20 @@ var resolvejson = (function () {
                 let ref = obj[refProp];
                 //we will always have the ref stored in the map
                 if (ref in byid) {
-                    return byid[ref];
+                    var wrk = byid[ref]
+                    if (Object.keys(obj).length == 1) {
+                        return wrk;
+                    }
+                    var rtn = {}
+                    for (var i in wrk) {
+                        rtn[i] = wrk[i]
+                    }
+                    for (var i in obj) {
+                        if (i != refProp && rtn[i] !== null) {
+                            rtn[i] = obj[i]
+                        }
+                    }
+                    return rtn;
                 } else {
                     return obj
                 }

--- a/resolvejson.js
+++ b/resolvejson.js
@@ -1,0 +1,56 @@
+// Usage
+// -----
+// The module exports one entry point, the `resovlejson()` function. It takes in
+// the JSON that has id/ref that you want to render as a single argument and returns JSON
+// with whatever graph cycles that are in the document.  Note that typically you can't
+// fully expand the json as its a graph.  But when navigating via the + sign it is what
+// you would expect.
+//
+// There are two use cases,
+// the first is microsoft's encodes it's graphs with $id $ref, to avoid cyclic graphs
+// (or just to save space).  This is resolved renderjson(resolvejson("$id","$idref", ...
+//
+// the second is for json schema's they encode their graphs with id $ref
+// These can be resolved by renderjson(resolvejson("id", "$ref", ...
+var resolvejson = (function () {
+    var resolvejson = function resolvejson(idProp, refProp, json) {
+        let byid = {}; //dictionary to keep the reference objects
+        (function collectObjIds(o) {
+            if (o.hasOwnProperty(idProp)) {
+                let id = o[idProp];
+                byid[id] = o;
+            }
+            for (var i in o) {
+                if (o[i] !== null && typeof (o[i]) == "object")
+                    collectObjIds(o[i]);
+            }
+        })(json)
+        json = (function replaceRefs(obj) {
+            if (typeof obj !== 'object' || !obj) // a primitive value
+                return obj;
+            if (obj.hasOwnProperty(refProp)) {
+                let ref = obj[refProp];
+                //we will always have the ref stored in the map
+                if (ref in byid) {
+                    return byid[ref];
+                } else {
+                    return obj
+                }
+            }
+            if (Array.isArray(obj)) {
+                obj = obj.map(replaceRefs);
+            } else {
+                for (let prop in obj) {
+                    obj[prop] = replaceRefs(obj[prop]);
+                }
+            }
+            return obj;
+        })(json);
+
+        return json;
+    }
+    return resolvejson;
+})();
+
+if (define) define({resolvejson: resolvejson})
+else (module || {}).exports = (window || {}).resolvejson = resolvejson;

--- a/test.html
+++ b/test.html
@@ -21,6 +21,15 @@
 
     <div id="dest"></div>
 
+    <h2>Json schema</h2>
+
+    <div id="schema"></div>
+
+    <h2>Microsoft id/ref</h2>
+
+    <div id="idref"></div>
+
+    <script type="text/javascript" src="resolvejson.js"></script>
     <script type="text/javascript" src="renderjson.js"></script>
     <script>
 document.getElementById("dest").appendChild(
@@ -245,6 +254,151 @@ renderjson.set_property_list(void 0)
     else return v;
 });
 document.getElementById("dest").appendChild(renderjson({ window: window, document: document, bad_nums:[1/0, parseInt("abcd")], "#dest":document.getElementById("dest") }));
+document.getElementById("idref").appendChild(
+        renderjson(
+            resolvejson("$id", "$ref",
+                [
+                    {
+                        "$id":"1",
+                        "Name":"Alice",
+                        "Sibling":{
+                            "$id":"2",
+                            "Name":"Bob",
+                            "Sibling":{
+                                "$ref":"1"
+                            }
+                        }
+                    },
+                    {
+                        "$ref":"2"
+                    }
+                ]
+            )
+        )
+    )
+
+document.getElementById("schema").appendChild(
+        renderjson(
+            resolvejson("id", "$ref",
+                {
+                    "type": "object",
+                    "id": "urn:jsonschema:rmistry:schema:test:SimpleSubClassRoot",
+                    "properties": {
+                        "action": {
+                            "type": "object",
+                            "id": "urn:jsonschema:rmistry:schema:test:AppAction",
+                            "required": true,
+                            "oneOf": [{
+                                "$ref": "urn:jsonschema:rmistry:schema:test:AddActivityAppAction"
+                            }, {
+                                "$ref": "urn:jsonschema:rmistry:schema:test:AddNoteAppAction"
+                            }, {
+                                "$ref": "urn:jsonschema:rmistry:schema:test:AppAction"
+                            }]
+                        }
+                    },
+                    "definitions": {
+                        "urn:jsonschema:rmistry:schema:test:AssignTo": {
+                            "type": "object",
+                            "id": "urn:jsonschema:rmistry:schema:test:AssignTo",
+                            "required": true,
+                            "oneOf": [{
+                                "$ref": "urn:jsonschema:rmistry:schema:test:AssignToDefault"
+                            }, {
+                                "$ref": "urn:jsonschema:rmistry:schema:test:AssignToGroup"
+                            }]
+                        },
+                        "urn:jsonschema:rmistry:schema:test:AssignToDefault": {
+                            "type": "object",
+                            "id": "urn:jsonschema:rmistry:schema:test:AssignToDefault",
+                            "additionalProperties": false,
+                            "properties": {
+                                "properties": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "target": {
+                                    "type": "string",
+                                    "required": true
+                                }
+                            }
+                        },
+                        "urn:jsonschema:rmistry:schema:test:AssignToGroup": {
+                            "type": "object",
+                            "id": "urn:jsonschema:rmistry:schema:test:AssignToGroup",
+                            "additionalProperties": false,
+                            "properties": {
+                                "groupName": {
+                                    "type": "string",
+                                    "required": true
+                                },
+                                "target": {
+                                    "type": "string",
+                                    "required": true
+                                }
+                            }
+                        },
+                        "urn:jsonschema:rmistry:schema:test:AddActivityAppAction": {
+                            "type": "object",
+                            "id": "urn:jsonschema:rmistry:schema:test:AddActivityAppAction",
+                            "additionalProperties": false,
+                            "properties": {
+                                "action": {
+                                    "type": "string",
+                                    "required": true
+                                },
+                                "addToParent": {
+                                    "type": "boolean"
+                                },
+                                "assignTo": {
+                                    "type": "object",
+                                    "$ref": "urn:jsonschema:rmistry:schema:test:AssignTo",
+                                    "required": true
+                                },
+                                "properties": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "urn:jsonschema:rmistry:schema:test:AddNoteAppAction": {
+                            "type": "object",
+                            "id": "urn:jsonschema:rmistry:schema:test:AddNoteAppAction",
+                            "additionalProperties": false,
+                            "properties": {
+                                "action": {
+                                    "type": "string",
+                                    "required": true
+                                },
+                                "addToParent": {
+                                    "type": "boolean"
+                                },
+                                "markConfidential": {
+                                    "type": "boolean",
+                                    "required": true
+                                },
+                                "properties": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "topic": {
+                                    "type": "string",
+                                    "required": true
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        )
+    )
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
This is how we solved the problem with microsofts $id/$ref graph reduction strategy.  We basically replaced the objects with $ref with the referenced object.  It also permits us to use the same navigation for json schema's id $ref.

