### PR TITLE
Fix ES6 default export

### DIFF
--- a/renderjson.js
+++ b/renderjson.js
@@ -214,3 +214,6 @@ var module, window, define, renderjson=(function() {
 
 if (define) define({renderjson:renderjson})
 else (module||{}).exports = (window||{}).renderjson = renderjson;
+
+// Export ES6 compatible
+export default renderjson;


### PR DESCRIPTION
Added ES6 export, can be used like:

`import renderjson from 'renderjson`